### PR TITLE
Change primary image source to audubon thumbnail

### DIFF
--- a/src/components/BirdCard.js
+++ b/src/components/BirdCard.js
@@ -19,10 +19,12 @@ const imageStyle= {
 
 export default function BirdCard(props) {
 
+  const url = props.bird.attributes.image_url.replace("bird_illustration", "nas_bird_teaser_illustration")
+
   return (
     <Link to={`/birds/${props.bird.id}`}>
       <div style={cardStyle}>
-        <img src={props.bird.attributes.image_url} 
+        <img src={url} 
           style={imageStyle} 
           alt={props.bird.attributes.name} />
         <br />

--- a/src/components/BirdShow.js
+++ b/src/components/BirdShow.js
@@ -3,12 +3,12 @@ import { connect } from 'react-redux'
 
 const BirdShow = (props) => {
 
-  // console.log(props.match)
-  // return null
+  const url = props.bird.attributes.image_url.replace("bird_illustration", "nas_bird_teaser_illustration")
+
   return (
     <div>
       <h1>Bird Detail</h1>
-      <img src={props.bird.attributes.image_url} 
+      <img src={url} 
         alt={props.bird.attributes.name} />
       <br />
       <b>{props.bird.attributes.name}</b>

--- a/src/components/DayDisplay.js
+++ b/src/components/DayDisplay.js
@@ -7,9 +7,8 @@ class DayDisplay extends React.Component {
     return (
       ids.map((id, idx) => {
         const bird = this.props.birds.find(b => b.id === id.toString()) // toString cleans up warnings
-        const url = bird.attributes.image_url.replace("nas_bird_teaser_illustration", "bird_illustration")
         return <img 
-          src={url} 
+          src={bird.attributes.image_url} 
           style={{maxHeight: "60px", maxWidth: "60px", margin: "5px 5px 10px 10px"}} 
           key={idx} 
           alt={bird.attributes.name} />


### PR DESCRIPTION
The urls for the thumbnail illustrations are much easier to capture, by right-clicking on the illustration shown on the birds' audubon page. The url is then used to create a new bird in the app. For components that require access to the larger illustration, a replace() alters the url to point to the larger version of the same image. 